### PR TITLE
Fixes/Tidy ups for testUltrasonic

### DIFF
--- a/ModuleTests/testGroveUltrasonic/testGroveUltrasonic.ino
+++ b/ModuleTests/testGroveUltrasonic/testGroveUltrasonic.ino
@@ -1,0 +1,58 @@
+//
+// For the Grove Ultrasonic Sensor provided with the Sensor Pack for Petoi Bittle.
+//
+
+// Pins
+#define RANGER 6 // Ranger pin is used to trigger (OUT) and detect echo (IN)
+
+// Physical constants
+#define LONGEST_DISTANCE_CM (200l) // 200 cm = 2 meters
+#define LONGEST_DISTANCE_M (LONGEST_DISTANCE_CM / 100l)
+#define SPEED_OF_SOUND_MPS (343l) // meters/second
+#define USEC_PER_SEC (1000000l)
+#define MAX_ECHO_TIME_US ((2l * USEC_PER_SEC * LONGEST_DISTANCE_M) / SPEED_OF_SOUND_MPS)
+#define SPEED_OF_SOUND_CMPS (SPEED_OF_SOUND_MPS * 100l)
+
+long measure_distance_cm()
+{
+  // Clears the trigPin
+  pinMode(RANGER, OUTPUT);
+  digitalWrite(RANGER, LOW);
+  delayMicroseconds(2);
+
+  // Trigger the ranger
+  digitalWrite(RANGER, HIGH);
+  delayMicroseconds(5);
+  digitalWrite(RANGER, LOW);
+
+  // Set ranger pin to input - the same pin is used for trigger and echo
+  pinMode(RANGER, INPUT);
+
+  // Reads the echoPin, returns the sound wave travel time in microseconds
+  long duration = pulseIn(RANGER, HIGH, MAX_ECHO_TIME_US);
+
+  // Calculating the distance (divide by two because sound is echoed)
+  return (SPEED_OF_SOUND_CMPS * duration) / (2 * USEC_PER_SEC);
+}
+
+void setup()
+{
+  pinMode(RANGER, INPUT); // Sets the echoPin as an Input
+  Serial.begin(115200);   // Starts the serial communication
+}
+
+long counter = 0;
+void loop()
+{
+  long distance = measure_distance_cm();
+
+  Serial.print("[");
+  Serial.print(counter++);
+  Serial.print("]:\t");
+  // Prints the distance on the Serial Monitor
+  Serial.print("Distance: ");
+  Serial.print(distance);
+  Serial.println(" cm");
+
+  delay(100);
+}


### PR DESCRIPTION
The `testUltrasonic.ino` file was not compatible with the "Grove Ultrasonic Ranger` which I received in the Bittle Sensor Pack.

The difference was that the "Grove Ultrasonic Ranger" only uses one pin for input/output.

## Changes:
* Support single pin ultrasonic ranging
* Tidy up of code
* Use physics based `#define`s to make it clear why we are using different constants (e.g. speed of sound)

## Testing

I used a super sophisticated test setup 😜 

<img width="848" alt="image" src="https://user-images.githubusercontent.com/4222666/121801347-f8ffd100-cc8a-11eb-815c-b35a0dfbc6b2.png">

Tested well at 15cm, 10cm and 5cm