### PR TITLE
Slow and smooth motion for older NyBoards

### DIFF
--- a/src/reaction.h
+++ b/src/reaction.h
@@ -280,6 +280,7 @@ void reaction() {
 #ifdef MAIN_SKETCH
   if (token == T_SKILL) {
     skill.perform();
+    delayMicroseconds(850); //Slow the robot down to smooth out motion; adjust delay PRN
   }
   if (skill.period < 0 ) {
     if (exceptions && skill.lookupAddressByName(lastCmd) > 0) { //lastToken == T_SKILL && lastSkill->period > 0) {


### PR DESCRIPTION
Delay added after skill execution as per discussion here: https://www.petoi.camp/forum/software/opencat-2-0-change-in-servo-designations-won-t-walk-backwards.