### PR TITLE
adding support for raspberry pi's and newer OS's

### DIFF
--- a/serialMaster/SerialCommunication.py
+++ b/serialMaster/SerialCommunication.py
@@ -4,6 +4,7 @@
 # modified from https://blog.csdn.net/u013541325/article/details/113062191
 
 import binascii
+import glob
 import os
 import serial  # need to install pyserial first
 import serial.tools.list_ports
@@ -104,7 +105,6 @@ class Communication(object):
         # it classifies the /dev/ttyS0 port as a platform port and therefore won't be queried
         # https://github.com/pyserial/pyserial/issues/489
         if os.name == 'posix' and sys.platform.lower()[:5] == 'linux':
-            import glob
             extra_ports = glob.glob('/dev/ttyS*')
             for port in extra_ports:
                 if port not in port_list_number:

--- a/serialMaster/SerialCommunication.py
+++ b/serialMaster/SerialCommunication.py
@@ -4,8 +4,10 @@
 # modified from https://blog.csdn.net/u013541325/article/details/113062191
 
 import binascii
+import os
 import serial  # need to install pyserial first
 import serial.tools.list_ports
+import sys
 
 # global variables
 # whether the serial port is created successfully or not
@@ -96,7 +98,17 @@ class Communication(object):
             for each_port in port_list:
                 port_list_number.append(each_port[0])
                 port_list_name.append(each_port[1])
-
+ 
+        # currently an issue in pyserial where for newer raspiberry pi os
+        # (Kernel version: 6.1, Debian version: 12 (bookworm)) or ubuntus (22.04)
+        # it classifies the /dev/ttyS0 port as a platform port and therefore won't be queried
+        # https://github.com/pyserial/pyserial/issues/489
+        if os.name == 'posix' and sys.platform.lower()[:5] == 'linux':
+            import glob
+            extra_ports = glob.glob('/dev/ttyS*')
+            for port in extra_ports:
+                if port not in port_list_number:
+                    port_list_number.append(port)
 #        print(port_list_number)
 #        print(port_list_name)
         return port_list_number


### PR DESCRIPTION
pyserial can't find /dev/ttyS0 for some newer raspberry pi operating systems (and ubuntu). This works around that. Also for me to use a raspberry pi headless (no desktop environment) the `serialMaster/config.py` needs to have `useMindPlus = True`. I'm not sure what this config does and I didn't look into it. Perhaps someone here has some more context, or its simply that the docs should be updated (https://docs.petoi.com/apis/raspberry-pi-serial-port-as-an-interface). 
https://github.com/pyserial/pyserial/issues/489. py serial can't find /dev/ttyS0.  